### PR TITLE
Replace blanket with Istanbul.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Covy
 ----
 
-Covy configures a test environment using Mocha, Chai, Sinon & Blanket
+Covy configures a test environment using Mocha, Chai, Sinon & Istanbul
 
 ## Installation
 
@@ -11,36 +11,13 @@ npm install covy
 
 ## Getting started
 
-By default `mocha` use a `./test` directory, so you should have one.
+`covy` use the `./test` directory and search for all `.test.js` files.
 
-Then create a `index.js`:
-
-```javascript
-var Covy = require('covy');
-
-new Covy({
-  path: __dirname,
-  blanket: {
-    'data-cover-never': 'node_modules',
-    'spec-cov': {
-      threshold: 15,
-      localThreshold: 15
-    },
-    pattern: [
-      'server.js',
-      'lib',
-      // others files/directories you want to code coverage.
-    ]
-  }
-});
-```
-
-then add those scripts in your `package.json`:
+Add those scripts in your `package.json`:
 
 ```json
 "scripts:" {
-  "test": "node test/index.js",
-  "cov": "REPORTER=html-cov node test/index.js > cov.html && open cov.html"
+  "test": "covy",
+  "cov": "istanbul cov covy"
 }
 ```
-

--- a/bin/covy
+++ b/bin/covy
@@ -2,8 +2,4 @@
 
 var Covy = require('../index');
 
-var covy = new Covy();
-
-covy.on('end', function (failures) {
-  process.exit(failures);
-});
+GLOBAL.covy = new Covy();

--- a/bin/covy
+++ b/bin/covy
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+var path = require('path');
+
+var Covy = require('../index');
+
+var covy = new Covy({
+  path: path.join(process.cwd(), 'test'),
+  ext: process.env['EXT'],
+  force_cov: process.env['FORCE_COV'],
+  blanket: {
+    'data-cover-never': 'node_modules',
+    'spec-cov': {
+      threshold: 15,
+      localThreshold: 15
+    },
+    pattern: ['src']
+  },
+  mocha: {
+    reporter: process.env['REPORTER'],
+    grep: process.env['GREP'],
+    ui: process.env['UI']
+  }
+});
+
+covy.on('end', function (failures) {
+  process.exit(failures);
+});

--- a/bin/covy
+++ b/bin/covy
@@ -1,18 +1,8 @@
 #!/usr/bin/env node
 
-var path = require('path');
-
 var Covy = require('../index');
 
-var covy = new Covy({
-  path: path.join(process.cwd(), 'test'),
-  ext: process.env['EXT'],
-  mocha: {
-    reporter: process.env['REPORTER'],
-    grep: process.env['GREP'],
-    ui: process.env['UI']
-  }
-});
+var covy = new Covy();
 
 covy.on('end', function (failures) {
   process.exit(failures);

--- a/bin/covy
+++ b/bin/covy
@@ -7,15 +7,6 @@ var Covy = require('../index');
 var covy = new Covy({
   path: path.join(process.cwd(), 'test'),
   ext: process.env['EXT'],
-  force_cov: process.env['FORCE_COV'],
-  blanket: {
-    'data-cover-never': 'node_modules',
-    'spec-cov': {
-      threshold: 15,
-      localThreshold: 15
-    },
-    pattern: ['src']
-  },
   mocha: {
     reporter: process.env['REPORTER'],
     grep: process.env['GREP'],

--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ function Covy (options) {
     ext: process.env['EXT'] || options.ext || '.test.js',
     reporter: process.env['REPORTER'] || options.reporter || 'nyan',
     grep: process.env['GREP'] || options.grep,
-    ui: process.env['UI'] || options.ui || 'bdd'
+    ui: process.env['UI'] || options.ui || 'bdd',
+    onEndExit: options.onEndExit || true
   };
 
   this.mocha = new Mocha({
@@ -64,13 +65,16 @@ Covy.prototype.files = function files () {
 Covy.prototype.run = function run () {
   this.mocha.run(function (failures) {
     if (!process.stdout.bufferSize) {
-      this.emit('end', failures);
+      this._end(failures);
     } else {
-      process.stdout.on('drain', function () {
-        this.emit('end', failures);
-      }.bind(this));
+      process.stdout.on('drain', this._end.bind(this, failures));
     }
   }.bind(this));
+};
+
+Covy.prototype._end = function _end (failures) {
+  this.emit('end', failures);
+  if (this.options.onEndExit) { process.exit(failures); }
 };
 
 module.exports = Covy;

--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ function Covy (options) {
   options = options || {};
   options.mocha = options.mocha || {};
 
-  this.blanketOptions = options.blanket;
   this.path = options.path;
   this.ext = options.ext || '.test.js';
 
@@ -39,10 +38,6 @@ function Covy (options) {
 
   this.mocha = new Mocha(options.mocha);
 
-  if (options.force_cov || this.mocha.options.reporter.match('cov')) {
-    this.blanket();
-  }
-
   this.files()
     .forEach(this.mocha.addFile.bind(this.mocha));
 
@@ -50,10 +45,6 @@ function Covy (options) {
 }
 
 inherits(Covy, EventEmitter);
-
-Covy.prototype.blanket = function blanket () {
-  return require('blanket')(this.blanketOptions);
-};
 
 Covy.prototype.files = function files () {
   return fs.readdirSync(this.path)

--- a/index.js
+++ b/index.js
@@ -28,15 +28,20 @@ GLOBAL.expect = chai.expect;
 function Covy (options) {
   EventEmitter.call(this);
   options = options || {};
-  options.mocha = options.mocha || {};
 
-  this.path = options.path;
-  this.ext = options.ext || '.test.js';
+  this.options = {
+    path: options.path || path.join(process.cwd(), 'test'),
+    ext: process.env['EXT'] || options.ext || '.test.js',
+    reporter: process.env['REPORTER'] || options.reporter || 'nyan',
+    grep: process.env['GREP'] || options.grep,
+    ui: process.env['UI'] || options.ui || 'bdd'
+  };
 
-  options.mocha.reporter = options.mocha.reporter || 'nyan';
-  options.mocha.ui = options.mocha.ui || 'bdd';
-
-  this.mocha = new Mocha(options.mocha);
+  this.mocha = new Mocha({
+    reporter: this.options.reporter,
+    grep: this.options.grep,
+    ui: this.options.ui
+  });
 
   this.files()
     .forEach(this.mocha.addFile.bind(this.mocha));
@@ -47,12 +52,12 @@ function Covy (options) {
 inherits(Covy, EventEmitter);
 
 Covy.prototype.files = function files () {
-  return fs.readdirSync(this.path)
+  return fs.readdirSync(this.options.path)
     .filter(function (f) {
-      return f.substr(~this.ext.length + 1) === this.ext;
+      return f.substr(~this.options.ext.length + 1) === this.options.ext;
     }.bind(this))
     .map(function (file) {
-      return path.join(this.path, file);
+      return path.join(this.options.path, file);
     }.bind(this));
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covy",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Covy configures a test environment using Mocha, Chai, Sinon & Blanket",
   "main": "index.js",
   "bin": "./bin/covy",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "Covy configures a test environment using Mocha, Chai, Sinon & Blanket",
   "main": "index.js",
+  "bin": "./bin/covy",
   "repository": {
     "url": "https://github.com/samjoch/covy.git",
     "type": "git"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "test": "mocha"
   },
   "author": "Sam Joch",
+  "contributors": [
+    "Thomas Cholley (https://github.com/waidd)",
+    "Nicolas Deveaud (https://github.com/LeMisterV)"
+  ],
   "license": "ISC",
   "dependencies": {
     "istanbul": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "covy",
   "version": "2.0.0",
-  "description": "Covy configures a test environment using Mocha, Chai, Sinon & Blanket",
+  "description": "Covy configures a test environment using Mocha, Chai, Sinon & Istanbul",
   "main": "index.js",
-  "bin": "./bin/covy",
+  "bin": {
+    "covy": "./bin/covy",
+    "istanbul": "node_modules/istanbul/lib/cli.js"
+  },
   "repository": {
     "url": "https://github.com/samjoch/covy.git",
     "type": "git"
@@ -14,7 +17,7 @@
   "author": "Sam Joch",
   "license": "ISC",
   "dependencies": {
-    "blanket": "^1.2.1",
+    "istanbul": "^0.4.4",
     "chai": "^3.4.1",
     "coffee-script": "^1.10.0",
     "mocha": "^2.3.4",


### PR DESCRIPTION
As Blanket is not anymore actively maintained and does not support ES6, we should replace it with a more recent library : Istanbul.
